### PR TITLE
Be able to publish by NPM OIDC config

### DIFF
--- a/.github/workflows/npm_publish_release.yml
+++ b/.github/workflows/npm_publish_release.yml
@@ -54,7 +54,7 @@ jobs:
         id: npm-version
         run: echo "npm=$(npm -v)" >> $GITHUB_OUTPUT
 
-      - name: Check npm version >= 11.5.1 to ensure OIDC support
+      - name: Compare npm version >= 11.5.1
         uses: madhead/semver-utils@latest
         id: npm_version_check
         with:

--- a/.github/workflows/npm_publish_release.yml
+++ b/.github/workflows/npm_publish_release.yml
@@ -49,18 +49,36 @@ jobs:
       - uses: volta-cli/action@v4
         with:
           registry-url: https://registry.npmjs.org
+      
+      - name: Create npmrc for install (read token)
+        if: steps.release.outputs.version_has_changed == 'true'
+        run: |
+          cat > .npmrc.install <<'EOF'
+          @boxid:registry=https://registry.npmjs.org/
+          //registry.npmjs.org/:_authToken=${NPM_TOKEN_READ_ALL}
+          always-auth=true
+          EOF
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_READ_ALL }}
+          NPM_TOKEN_READ_ALL: ${{ secrets.NPM_TOKEN_READ_ALL }}
 
       - name: Install Dependencies
         if: steps.release.outputs.version_has_changed == 'true'
         run: npm ci
+        env:
+          NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/.npmrc.install
 
       - name: Build Project
         if: steps.release.outputs.version_has_changed == 'true'
         run: npm run compile
 
-      - name: Publish to npm
+      - name: Create empty npmrc for publish (OIDC)
+        if: steps.release.outputs.version_has_changed == 'true'
+        run: |
+          : > .npmrc.publish
+
+      - name: Publish to npm (OIDC trusted publisher)
         if: steps.release.outputs.version_has_changed == 'true'
         # publish authentication is done by the trusted provider OICD setting within the NPM package settings 
         run: npm publish --access restricted
+        env:
+          NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/.npmrc.publish

--- a/.github/workflows/npm_publish_release.yml
+++ b/.github/workflows/npm_publish_release.yml
@@ -75,6 +75,12 @@ jobs:
         if: steps.release.outputs.version_has_changed == 'true'
         run: |
           : > .npmrc.publish
+          
+      - name: Debug npm auth
+        run: |
+          echo "userconfig=$NPM_CONFIG_USERCONFIG"
+          npm config get //registry.npmjs.org/:_authToken || true
+          env | sort | grep -E 'ACTIONS_ID_TOKEN|NPM_CONFIG_USERCONFIG|NODE_AUTH_TOKEN' || true
 
       - name: Publish to npm (OIDC trusted publisher)
         if: steps.release.outputs.version_has_changed == 'true'

--- a/.github/workflows/npm_publish_release.yml
+++ b/.github/workflows/npm_publish_release.yml
@@ -50,17 +50,19 @@ jobs:
         with:
           registry-url: https://registry.npmjs.org
 
-      - name: Show tool versions
-        run: |
-          node -v
-          npm -v
-          
-      - name: Upgrade npm for Trusted Publishing (OIDC)
-        run: npm i -g npm@^11.5.1
-      
-      - name: Confirm npm version
-        run: npm -v
-      
+      - uses: volta-cli/action@v4
+
+      - name: Get npm version
+        id: npm-version
+        run: echo "npm=$(npm -v)" >> $GITHUB_OUTPUT
+
+      - name: Check npm version >= 11.5.1 to ensure OIDC support
+        uses: madhead/semver-utils@latest
+        id: npm_version_check
+        with:
+          version: ${{ steps.npm-version.outputs.npm }}
+          satisfies: ">=11.5.1"
+
       - name: Create npmrc for install (read token)
         if: steps.release.outputs.version_has_changed == 'true'
         run: |
@@ -86,19 +88,10 @@ jobs:
         if: steps.release.outputs.version_has_changed == 'true'
         run: |
           : > .npmrc.publish
-          
-      - name: Debug npm auth
-        run: |
-          echo "userconfig=$NPM_CONFIG_USERCONFIG"
-          npm config get //registry.npmjs.org/:_authToken || true
-          env | sort | grep -E 'ACTIONS_ID_TOKEN|NPM_CONFIG_USERCONFIG|NODE_AUTH_TOKEN' || true
-        env:
-          NODE_AUTH_TOKEN: ""
-          NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/.npmrc.publish
 
       - name: Publish to npm (OIDC trusted publisher)
         if: steps.release.outputs.version_has_changed == 'true'
-        # publish authentication is done by the trusted provider OICD setting within the NPM package settings 
+        # publish authentication is done by the trusted provider OICD setting within the NPM package settings
         run: npm publish --access restricted
         env:
           NODE_AUTH_TOKEN: ""

--- a/.github/workflows/npm_publish_release.yml
+++ b/.github/workflows/npm_publish_release.yml
@@ -63,6 +63,12 @@ jobs:
           version: ${{ steps.npm-version.outputs.npm }}
           satisfies: ">=15.5.1"
 
+      - name: Check if npm version is compatible with OIDC trusted publisher
+        if: steps.npm_version_check.outputs.satisfies == 'false'
+        run: |
+          echo "npm version does not support OIDC trusted publisher. Please upgrade npm to 11.5.1 or higher."
+          exit 1
+
       - name: Create npmrc for install (read token)
         if: steps.release.outputs.version_has_changed == 'true'
         run: |

--- a/.github/workflows/npm_publish_release.yml
+++ b/.github/workflows/npm_publish_release.yml
@@ -50,8 +50,6 @@ jobs:
         with:
           registry-url: https://registry.npmjs.org
 
-      - uses: volta-cli/action@v4
-
       - name: Get npm version
         id: npm-version
         run: echo "npm=$(npm -v)" >> $GITHUB_OUTPUT
@@ -97,7 +95,7 @@ jobs:
 
       - name: Publish to npm (OIDC trusted publisher)
         if: steps.release.outputs.version_has_changed == 'true'
-        # publish authentication is done by the trusted provider OICD setting within the NPM package settings
+        # publish authentication is done by the trusted provider OIDC setting within the NPM package settings
         run: npm publish --access restricted
         env:
           NODE_AUTH_TOKEN: ""

--- a/.github/workflows/npm_publish_release.yml
+++ b/.github/workflows/npm_publish_release.yml
@@ -61,7 +61,7 @@ jobs:
         id: npm_version_check
         with:
           version: ${{ steps.npm-version.outputs.npm }}
-          satisfies: ">=15.5.1"
+          satisfies: ">=11.5.1"
 
       - name: Check if npm version is compatible with OIDC trusted publisher
         if: steps.npm_version_check.outputs.satisfies == 'false'

--- a/.github/workflows/npm_publish_release.yml
+++ b/.github/workflows/npm_publish_release.yml
@@ -63,4 +63,4 @@ jobs:
       - name: Publish to npm
         if: steps.release.outputs.version_has_changed == 'true'
         # publish authentication is done by the trusted provider OICD setting within the NPM package settings 
-        run: npm publish
+        run: npm publish --access restricted

--- a/.github/workflows/npm_publish_release.yml
+++ b/.github/workflows/npm_publish_release.yml
@@ -49,6 +49,17 @@ jobs:
       - uses: volta-cli/action@v4
         with:
           registry-url: https://registry.npmjs.org
+
+      - name: Show tool versions
+        run: |
+          node -v
+          npm -v
+          
+      - name: Upgrade npm for Trusted Publishing (OIDC)
+        run: npm i -g npm@^11.5.1
+      
+      - name: Confirm npm version
+        run: npm -v
       
       - name: Create npmrc for install (read token)
         if: steps.release.outputs.version_has_changed == 'true'
@@ -81,10 +92,14 @@ jobs:
           echo "userconfig=$NPM_CONFIG_USERCONFIG"
           npm config get //registry.npmjs.org/:_authToken || true
           env | sort | grep -E 'ACTIONS_ID_TOKEN|NPM_CONFIG_USERCONFIG|NODE_AUTH_TOKEN' || true
+        env:
+          NODE_AUTH_TOKEN: ""
+          NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/.npmrc.publish
 
       - name: Publish to npm (OIDC trusted publisher)
         if: steps.release.outputs.version_has_changed == 'true'
         # publish authentication is done by the trusted provider OICD setting within the NPM package settings 
         run: npm publish --access restricted
         env:
+          NODE_AUTH_TOKEN: ""
           NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/.npmrc.publish

--- a/.github/workflows/npm_publish_release.yml
+++ b/.github/workflows/npm_publish_release.yml
@@ -61,7 +61,7 @@ jobs:
         id: npm_version_check
         with:
           version: ${{ steps.npm-version.outputs.npm }}
-          satisfies: ">=11.5.1"
+          satisfies: ">=15.5.1"
 
       - name: Create npmrc for install (read token)
         if: steps.release.outputs.version_has_changed == 'true'

--- a/.github/workflows/npm_publish_release.yml
+++ b/.github/workflows/npm_publish_release.yml
@@ -55,7 +55,7 @@ jobs:
         run: echo "npm=$(npm -v)" >> $GITHUB_OUTPUT
 
       - name: Compare npm version >= 11.5.1
-        uses: madhead/semver-utils@latest
+        uses: madhead/semver-utils@v4
         id: npm_version_check
         with:
           version: ${{ steps.npm-version.outputs.npm }}

--- a/.github/workflows/npm_publish_release.yml
+++ b/.github/workflows/npm_publish_release.yml
@@ -76,7 +76,7 @@ jobs:
           always-auth=true
           EOF
         env:
-          NPM_TOKEN_READ_ALL: ${{ secrets.NPM_TOKEN_READ_ALL }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_READ_ALL }}
 
       - name: Install Dependencies
         if: steps.release.outputs.version_has_changed == 'true'

--- a/.github/workflows/npm_publish_release.yml
+++ b/.github/workflows/npm_publish_release.yml
@@ -62,6 +62,5 @@ jobs:
 
       - name: Publish to npm
         if: steps.release.outputs.version_has_changed == 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_PUBLISH }}
-        run: npm publish --access restricted
+        # publish authentication is done by the trusted provider OICD setting within the NPM package settings 
+        run: npm publish

--- a/.github/workflows/npm_version_bump.yml
+++ b/.github/workflows/npm_version_bump.yml
@@ -45,7 +45,7 @@ jobs:
         id: npm-version
         run: echo "npm=$(npm -v)" >> $GITHUB_OUTPUT
 
-      - name: Check npm version >= 11.5.1 to ensure OIDC support
+      - name: Check npm version >= 11.5.1 to ensure npm OIDC support is available
         uses: madhead/semver-utils@latest
         id: npm_version_check
         with:

--- a/.github/workflows/npm_version_bump.yml
+++ b/.github/workflows/npm_version_bump.yml
@@ -45,12 +45,18 @@ jobs:
         id: npm-version
         run: echo "npm=$(npm -v)" >> $GITHUB_OUTPUT
 
-      - name: Check npm version >= 11.5.1 to ensure npm OIDC support is available
+      - name: Compare npm version >= 11.5.1
         uses: madhead/semver-utils@latest
         id: npm_version_check
         with:
           version: ${{ steps.npm-version.outputs.npm }}
           satisfies: ">=11.5.1"
+
+      - name: Check if npm version is compatible with OIDC trusted publisher
+        if: steps.npm_version_check.outputs.satisfies == 'false'
+        run: |
+          echo "npm version does not support OIDC trusted publisher. Please upgrade npm to 11.5.1 or higher."
+          exit 1
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/npm_version_bump.yml
+++ b/.github/workflows/npm_version_bump.yml
@@ -50,7 +50,7 @@ jobs:
         id: npm_version_check
         with:
           version: ${{ steps.npm-version.outputs.npm }}
-          satisfies: ">=15.5.1"
+          satisfies: ">=11.5.1"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/npm_version_bump.yml
+++ b/.github/workflows/npm_version_bump.yml
@@ -41,6 +41,17 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_READ_ALL }}
 
+      - name: Get npm version
+        id: npm-version
+        run: echo "npm=$(npm -v)" >> $GITHUB_OUTPUT
+
+      - name: Check npm version >= 11.5.1 to ensure OIDC support
+        uses: madhead/semver-utils@latest
+        id: npm_version_check
+        with:
+          version: ${{ steps.npm-version.outputs.npm }}
+          satisfies: ">=15.5.1"
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/npm_version_bump.yml
+++ b/.github/workflows/npm_version_bump.yml
@@ -46,7 +46,7 @@ jobs:
         run: echo "npm=$(npm -v)" >> $GITHUB_OUTPUT
 
       - name: Compare npm version >= 11.5.1
-        uses: madhead/semver-utils@latest
+        uses: madhead/semver-utils@v4
         id: npm_version_check
         with:
           version: ${{ steps.npm-version.outputs.npm }}


### PR DESCRIPTION
The publish token is no longer functional as it lifetime is only a few weeks. The new correct version is setup Github as [Trusted Provider](https://docs.npmjs.com/trusted-publishers#supported-cicd-providers) via OICD within the NPM package settings.